### PR TITLE
Add spaces between words.

### DIFF
--- a/call-for-volunteers/index.md
+++ b/call-for-volunteers/index.md
@@ -6,9 +6,9 @@ layout: default
 
 # {{ page.title}}
 
-We are seeking volunteers for the 43rd Annual ACM SIGIRConference on Research and Development in Information Retrieval (SIGIR 2020), which will be held as a virtual conference during July 25-30, 2020. 
+We are seeking volunteers for the 43rd Annual ACM SIGIR Conference on Research and Development in Information Retrieval (SIGIR 2020), which will be held as a virtual conference during July 25-30, 2020. 
 
-Volunteers will participate in the organization of theconference. As SIGIR 2020 will be held as a virtual conference for the first time, we do need your help. A volunteer will work for a maximum of 8 hours during the conference. 
+Volunteers will participate in the organization of the conference. As SIGIR 2020 will be held as a virtual conference for the first time, we do need your help. A volunteer will work for a maximum of 8 hours during the conference. 
 
 The responsibilities of the volunteers include:
 * Attending a training session for volunteers before the conference
@@ -28,25 +28,25 @@ If you are interested in being a volunteer for SIGIR 2020, please fill [this for
 * Your location and time zone during SIGIR 2020
 * Are you a student?
 * The name of your institute
-* Advisor’s name (or the name of someone who canconfirm you are a student)
+* Advisor’s name (or the name of someone who can confirm you are a student)
 * Advisor’s email address
-* Do you plan to present a full paper, short paper,demonstration, or doctoral consortium paper at the conference?
+* Do you plan to present a full paper, short paper, demonstration, or doctoral consortium paper at the conference?
 * Why do you want to be a volunteer for SIGIR2020?
 * Have you attended a SIGIR Conference before?
 * Your motivation to attend to SIGIR 2020 and other information you consider worth to explain
 * Please also indicate, if applicable, days and times when you are unable to work as a volunteer
 
-As the number of places is limited, we will select thevolunteers based on:
+As the number of places is limited, we will select the volunteers based on:
 * Your motivation to help organize SIGIR 2020
 * Your current status (Students at all levels arepreferred, but non-students are also welcome)
 * Your location and time zone (Because the conference is for people from all around the world and in different time zones,the time of the sessions is deliberately scheduled that some of them are moreconvenient for the people in a certain time zone. Therefore, we need volunteers in different geo-locations and time zones.)
 * Your motivation to attend the conference (Why attending the conference is important for you? Is this the first time for youto attend a SIGIR conference?)
 
-**IMPORTANT**: Please submit your application before July4, 2020. The late applications will be considered only if there are unfilledpositions.
+**IMPORTANT**: Please submit your application before July 4, 2020. The late applications will be considered only if there are unfilled positions.
 
 **Contact email**: <sigir2020volunteers@gmail.com>
 
 **Application form**: [link to the form](https://wj.qq.com/s2/6614115/e17d/)
 
-**Application deadline**: **July, 4, 2020**
+**Application deadline**: **July 4, 2020**
 


### PR DESCRIPTION
Some necessary spaces used for separating two words were missed in the original call for volunteers page.